### PR TITLE
Adjusted Dockerfile and added logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
 FROM python:2-onbuild
 MAINTAINER SportArchive, Inc.
-ENTRYPOINT ["python", "bin/ct-decider.py"]
+
+ENV AWS_ACCESS_KEY_ID xyz
+ENV AWS_SECRET_ACCESS_KEY xyz
+ENV AWS_CONFIG_BUCKET xyz
+ENV AWS_CONFIG_KEY xyz
+
+ENTRYPOINT ["python", "/usr/src/app/bin/decider.py"]

--- a/bin/decider.py
+++ b/bin/decider.py
@@ -52,5 +52,6 @@ def main():
 
 if __name__ == '__main__':
     import logging
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG,
+                        filename="/var/log/cloudtranscode/decider.log")
     main()


### PR DESCRIPTION
Added a default log file to the decider (in the future would be better
to allow command-line customization of the logger).

Also indicated in Dockerfile that AWS credentials must be provided.
