### PR TITLE
Add SQS communication to SwfDecider

### DIFF
--- a/bin/decider.py
+++ b/bin/decider.py
@@ -31,11 +31,12 @@ def main():
     parser.add_argument('-d', '--domain', required=True, help='The SWF domain for your workflow')
     parser.add_argument('-t', '--task_list', required=True, help='The Decision TaskList your decider will listen to')
     parser.add_argument('--plan', required=True, help='The location of your Plan file')
+    parser.add_argument('--output_queue', required=True, help='SQS queue to output updates to')
     parser.add_argument('--plan_name', required=False, help='If you want to override the plan name in your Plan file')
     parser.add_argument('--plan_version', required=False, help='If you want to override the plan version in your Plan file')
     parser.add_argument('--log_file', required=False, help='Location of the log file')
     args = parser.parse_args()
-    
+
     log_file = "/var/tmp/logs/cpe/decider.log"
     if args.log_file:
         log_file = args.log_file
@@ -59,7 +60,7 @@ def main():
     register(domain=args.domain,
              workflows=((p.name, p.version),))
 
-    d = Decider(domain=args.domain, task_list=args.task_list, plan=p)
+    d = Decider(domain=args.domain, task_list=args.task_list, plan=p, output_queue=args.output_queue)
 
     while d.run():
         pass


### PR DESCRIPTION
Make the decider send messages to an SQS queue with updates on what
decision tasks are made.

A message is sent when a workflow fails due to a state machine
violation, and when an activity is scheduled.

[Delivers #109229588]
